### PR TITLE
Add check before use object methods on null

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -30,10 +30,16 @@ class Log {
     }
 
     public static function error($name, $message) {
+        if(empty(self::$instance[$name])){
+            die($message);
+        }
         self::$instance[$name]->error($message, self::$context);
     }
     
     public static function info($name, $message) {
+        if(empty(self::$instance[$name])){
+            die($message);
+        }
         self::$instance[$name]->info($message, self::$context);
     }
 


### PR DESCRIPTION
Фабула:

`api_1            | worker-ImportProductsToElasticserch-6  | Fatal error: Uncaught Error: Call to a member function error() on null in /var/www/vendor/memcrab/log/src/Log.php on line 33
api_1            | worker-ImportProductsToElasticserch-6  | Error: Call to a member function error() on null in /var/www/vendor/memcrab/log/src/Log.php on line 33
api_1            | worker-ImportProductsToElasticserch-6  | Call Stack:
api_1            | worker-ImportProductsToElasticserch-6  |     0.0003     429296   1. {main}() /var/www/workers/Worker.php:0
api_1            | worker-ImportProductsToElasticserch-6  |     0.0210    2225200   2. memCrab\File\Yaml->load() /var/www/workers/Worker.php:19
api_1            | worker-ImportProductsToElasticserch-6  |     0.0210    2225200   3. memCrab\File\Yaml->parseYamlFile() /var/www/vendor/memcrab/file/src/Yaml.php:18
api_1            | worker-ImportProductsToElasticserch-6  |     0.0210    2225240   4. yaml_parse_file() /var/www/vendor/memcrab/file/src/Yaml.php:27
api_1            | worker-ImportProductsToElasticserch-6  |     0.0216    2255328   5. handlerForNoticeAndWarning() /var/www/vendor/memcrab/file/src/Yaml.php:27
api_1            | worker-ImportProductsToElasticserch-6  |     0.0218    2331264   6. memCrab\Log\Log::error() /var/www/libs/Functions.php:243`

Эмуляция:
```
#Only for fatals!
set_error_handler("handlerForNoticeAndWarning");
register_shutdown_function('fatalHandler');
trigger_error('FATAL ERROR', E_USER_ERROR);
# Initialize Config Parser
$Yaml = new \memCrab\File\Yaml();
$routes = $Yaml->load(__DIR__ . "/config/routes.yaml", null)->getContent();
$accessRules = $Yaml->load(__DIR__ . "/config/rules.yaml", null)->getContent();
$configuration = $Yaml->load(getenv("CONFIG_PATH"), null)->getContent();
Config::loadConfiguration($configuration);
#For docker api container start
try {
    Log::setContext([
        'job' => 'api',
        'project' => 'meg',
        'instance' => gethostname(),
        'env' => Config::obj()->params['environment'],
        'os' => php_uname('s') . " " . php_uname('r'),
        'connectionType' => 'api',
    ]);
    Log::setAmqpHandler(
        Queue::obj()->channel(),
        Queue::obj()->getDeadLetterExchange(),
        "errors"
    );
```


Есть вероятность что скрипт не дойдет до инициализации механизма логирования через
` Log::setAmqpHandler()` и соответственно `stream()`, где собственно и определяются "каналы". Как именно произошло на продакшн(Фабула) сказать не могу. Возможно как-то связано с "прокидыванием" конфиг-файлов, удалось выудить из логов PM2.